### PR TITLE
Set delete flag on threads and posts instead of deleting entry

### DIFF
--- a/reviveme/api/v1/comment_controller.py
+++ b/reviveme/api/v1/comment_controller.py
@@ -52,6 +52,6 @@ def comment_update(comment_id):
 @bp.route("/comments/<int:comment_id>", methods=["DELETE"])
 def comment_delete(comment_id):
     comment = db.get_or_404(Comment, comment_id)
-    db.session.delete(comment)
+    comment.deleted = True
     db.session.commit()
     return Response(status=200)

--- a/reviveme/api/v1/thread_controller.py
+++ b/reviveme/api/v1/thread_controller.py
@@ -46,6 +46,6 @@ def thread_update(id):
 @bp.route("/threads/<int:id>", methods=["DELETE"])
 def thread_delete(id):
     thread = db.get_or_404(Thread, id)
-    db.session.delete(thread)
+    thread.deleted = True
     db.session.commit()
     return Response(status=200)

--- a/reviveme/models/comment.py
+++ b/reviveme/models/comment.py
@@ -1,15 +1,17 @@
-from sqlalchemy import ForeignKey, Text
+from sqlalchemy import ForeignKey, Text, Boolean
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from reviveme.db import db
 
+from typing import Union
 
 class Comment(db.Model):
     __tablename__ = "comments"
     id: Mapped[int] = mapped_column(primary_key=True)
     author_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"))
-    content: Mapped[str] = mapped_column(Text)
+    content: Mapped[Union[str, None]] = mapped_column(Text)
+    deleted: Mapped[bool] = mapped_column(Boolean, default=False)
 
     thread: Mapped["Thread"] = relationship("Thread", back_populates="comments")
 
@@ -24,7 +26,8 @@ class Comment(db.Model):
     def serialize(self):
         return {
             "id": self.id,
-            "author_id": self.author_id,
+            "author_id": self.author_id if not self.deleted else None,
             "thread_id": self.thread_id,
-            "content": self.content,
+            "content": self.content if not self.deleted else None,
+            "deleted": self.deleted,
         }

--- a/reviveme/models/thread.py
+++ b/reviveme/models/thread.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from sqlalchemy import ForeignKey, String
+from sqlalchemy import ForeignKey, String, Boolean
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from reviveme.db import db
@@ -12,6 +12,7 @@ class Thread(db.Model):
     author_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     title: Mapped[str] = mapped_column(String(120))
     content: Mapped[str] = mapped_column(String(10000))
+    deleted: Mapped[bool] = mapped_column(Boolean, default=False)
 
     comments: Mapped[List["Comment"]] = relationship("Comment", back_populates="thread")
     author: Mapped["User"] = relationship("User", back_populates="threads")
@@ -27,8 +28,9 @@ class Thread(db.Model):
     def serialize(self):
         return {
             "id": self.id,
-            "author_id": self.author_id,
-            "title": self.title,
-            "content": self.content,
-            "author_name": self.author.username,
+            "author_id": self.author_id if not self.deleted else None,
+            "title": self.title if not self.deleted else None,
+            "content": self.content if not self.deleted else None,
+            "author_name": self.author.username if not self.deleted else None,
+            "deleted": self.deleted,
         }

--- a/reviveme/tests/test_comment_controller.py
+++ b/reviveme/tests/test_comment_controller.py
@@ -170,8 +170,13 @@ class TestCommentController:
         response = client.delete(f'/api/v1/comments/{comment.id}')
         assert response.status_code == 200
 
-        comment = db.session.query(Comment).filter_by(id=comment.id).first()
-        assert comment is None
+        assert comment.deleted == True
+
+        resp = client.get(f'/api/v1/comments/{comment.id}')
+        assert resp.status_code == 200
+        assert resp.json["deleted"] == True
+        assert resp.json["content"] == None
+        assert resp.json["author_id"] == None
     
     def test_delete_comment_404(self, client):
         response = client.delete('/api/v1/comments/1')

--- a/reviveme/tests/test_thread_controller.py
+++ b/reviveme/tests/test_thread_controller.py
@@ -87,6 +87,16 @@ class TestThreadController():
         response = client.delete(f'/api/v1/threads/{thread.id}')
         assert response.status_code == 200
 
+        assert thread.deleted == True
+        
+        response = client.get(f'/api/v1/threads/{thread.id}')
+        assert response.status_code == 200
+        assert response.json["deleted"] == True
+        assert response.json["author_id"] == None
+        assert response.json["author_name"] == None
+        assert response.json["title"] == None
+        assert response.json["content"] == None
+
     def test_delete_thread_404(self, client):
         response = client.delete('/api/v1/threads/1')
         assert response.status_code == 404


### PR DESCRIPTION
This allows us to still access comments made under a deleted thread/comment.