### PR TITLE
Make comments nestable

### DIFF
--- a/reviveme/api/v1/comment_controller.py
+++ b/reviveme/api/v1/comment_controller.py
@@ -1,5 +1,6 @@
-from typing import Any
+from __future__ import annotations
 
+from typing import Any, List
 from flask import Response, request
 
 from reviveme import db
@@ -7,16 +8,54 @@ from reviveme.models import Comment, Thread
 
 from . import bp
 
+class CommentNode:
+    '''
+    Used to construct a tree of comments for easier serialization
+    '''
+    def __init__(self, comment: Comment):
+        self.comment = comment
+        self.children: List[CommentNode] = []
+
+    def add_child(self, node: CommentNode):
+        self.children.append(node)
+
+    def serialize(self):
+        return {
+            **self.comment.serialize(),
+            "children": [child.serialize() for child in self.children]
+        }
+
 
 @bp.route("/threads/<int:thread_id>/comments", methods=["GET"])
 def comment_list(thread_id):
     db.get_or_404(Thread, thread_id) # 404 if thread doesn't exist
+
     comments = (
-        db.session.execute(db.select(Comment).where(Comment.thread_id == thread_id))
+        db.session.execute(db.select(Comment).where(Comment.thread_id == thread_id).where(Comment.depth == 1))
         .scalars()
         .all()
     )
-    return [comment.serialize() for comment in comments]
+    depth = 2 # start at depth 2 since we already got depth 1
+    top_level_comments = [CommentNode(comment) for comment in comments]
+    # Save pointers to leaf nodes for easier insertion
+    prev_level_comments = {node.comment.id: node for node in top_level_comments}
+    while len(comments) > 0:
+        new_nodes = {}
+
+        comments = (
+            db.session.execute(db.select(Comment).where(Comment.thread_id == thread_id).where(Comment.depth == depth))
+            .scalars()
+            .all()
+        )
+        for comment in comments:
+            node = CommentNode(comment)
+            parent = prev_level_comments[comment.parent_id]
+            parent.add_child(node)
+            new_nodes[comment.id] = node
+        
+        prev_level_comments = new_nodes
+
+    return [comment.serialize() for comment in top_level_comments]
 
 
 @bp.route("/comments/<int:comment_id>", methods=["GET"])
@@ -33,7 +72,20 @@ def comment_create(thread_id):
 
     # TODO validate data in request body
     # TODO: get author_id from token once auth is implemented
-    comment = Comment(content=data["content"], thread_id=thread_id, author_id=1)
+    if data["parent_id"]:
+        db.get_or_404(Comment, data["parent_id"])
+        comment = Comment(
+            content=data["content"],
+            thread_id=thread_id,
+            author_id=1,
+            parent_id=data["parent_id"],
+        )
+    else:
+        comment = Comment(
+            content=data["content"], 
+            thread_id=thread_id, 
+            author_id=1
+        )
     db.session.add(comment)
     db.session.commit()
     return Response(status=201)

--- a/reviveme/api/v1/comment_controller.py
+++ b/reviveme/api/v1/comment_controller.py
@@ -54,6 +54,7 @@ def comment_list(thread_id):
             new_nodes[comment.id] = node
         
         prev_level_comments = new_nodes
+        depth += 1
 
     return [comment.serialize() for comment in top_level_comments]
 
@@ -72,7 +73,7 @@ def comment_create(thread_id):
 
     # TODO validate data in request body
     # TODO: get author_id from token once auth is implemented
-    if data["parent_id"]:
+    if "parent_id" in data:
         db.get_or_404(Comment, data["parent_id"])
         comment = Comment(
             content=data["content"],

--- a/reviveme/models/comment.py
+++ b/reviveme/models/comment.py
@@ -1,5 +1,6 @@
-from sqlalchemy import ForeignKey, Text
+from sqlalchemy import ForeignKey, Text, Integer
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import Union
 
 from reviveme.db import db
 
@@ -10,13 +11,24 @@ class Comment(db.Model):
     author_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"))
     content: Mapped[str] = mapped_column(Text)
+    parent_id: Mapped[Union[int, None]] = mapped_column(ForeignKey("comments.id"))
+    depth: Mapped[int] = mapped_column(Integer, default=1)
 
     thread: Mapped["Thread"] = relationship("Thread", back_populates="comments")
 
-    def __init__(self, author_id: int, thread_id: int, content: str):
+    def __init__(self, author_id: int, thread_id: int, content: str, parent_id: Union[int, None] = None):
         self.author_id = author_id
         self.thread_id = thread_id
         self.content = content
+        self.parent_id = parent_id
+
+        if parent_id is not None:
+            parent = db.session.get(Comment, parent_id)
+            if parent is None:
+                raise ValueError(f"Comment with id {parent_id} does not exist")
+            self.depth = parent.depth + 1
+        else:
+            self.depth = 1
 
     def __repr__(self):
         return f"<Comment id={self.id!r}, author_id={self.author_id!r}, thread_id={self.thread_id!r} content={self.content!r}>"


### PR DESCRIPTION
Now, the list endpoint displays comments' children. The results look a little like this:
```json
[
  {
    "author_id": 2,
    "children": [],
    "content": "This is a comment made by Jane",
    "deleted": false,
    "id": 1,
    "thread_id": 1
  },
  {
    "author_id": 2,
    "children": [
      {
        "author_id": 1,
        "children": [
          {
            "author_id": 1,
            "children": [
              {
                "author_id": 1,
                "children": [],
                "content": "another asdfasdfasdfasdfasdf comment",
                "deleted": false,
                "id": 6,
                "thread_id": 1
              },
            ],
            "content": "asdfasdfasdfasdfasdf comment",
            "deleted": false,
            "id": 5,
            "thread_id": 1
          }
        ],
        "content": "This is a reply made by John",
        "deleted": false,
        "id": 4,
        "thread_id": 1
      }
    ],
    "content": "This is another comment made by Jane",
    "deleted": false,
    "id": 2,
    "thread_id": 1
  },
```

Additionally, the create comment endpoint now takes an optional `parent_id` key in the request body. If unspecified, we create a top-level comment by default.