### PR TITLE
Use marshmallow for deserialization and validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ typing_extensions==4.8.0
 virtualenv==20.24.6
 Werkzeug==3.0.1
 pytest==7.4.3
+marshmallow==3.20.1

--- a/reviveme/api/v1/__init__.py
+++ b/reviveme/api/v1/__init__.py
@@ -1,5 +1,10 @@
-from flask import Blueprint
+from flask import Blueprint, jsonify
+import marshmallow as ma
 
 bp = Blueprint("v1", __name__)
+
+@bp.errorhandler(ma.ValidationError)
+def handle_validation_error(error):
+    return jsonify(error.messages), 400
 
 from . import comment_controller, routes, thread_controller, user_controller

--- a/reviveme/api/v1/comment_controller.py
+++ b/reviveme/api/v1/comment_controller.py
@@ -6,7 +6,7 @@ from flask import Response, jsonify, request
 from reviveme import db
 from reviveme.models import Comment, Thread
 
-from marshmallow import Schema, fields, post_load, validate, validates
+from marshmallow import Schema, fields, post_load, validate, validates, ValidationError
 
 from . import bp
 
@@ -20,7 +20,7 @@ class CommentSchema(Schema):
     @validates("parent_id")
     def validate_parent_id(self, parent_id):
         if parent_id is not None and db.session.get(Comment, parent_id) is None:
-            raise ValueError(f"Comment with id {parent_id} does not exist")
+            raise ValidationError(f"Comment with id {parent_id} does not exist")
 
     @post_load
     def make_comment(self, data, **kwargs) -> Comment:

--- a/reviveme/api/v1/comment_controller.py
+++ b/reviveme/api/v1/comment_controller.py
@@ -92,7 +92,7 @@ def comment_create(thread_id):
     schema = CommentSchema()
     # TODO: get author_id from token once auth is implemented
     schema.author_id, schema.thread_id = 1, thread_id
-    comment = schema.load(data, thread_id=thread_id, author_id=1)
+    comment = schema.load(data)
     db.session.add(comment)
     db.session.commit()
     return Response(status=201)

--- a/reviveme/api/v1/comment_controller.py
+++ b/reviveme/api/v1/comment_controller.py
@@ -1,12 +1,30 @@
 from __future__ import annotations
 
 from typing import Any, List
-from flask import Response, request
+from flask import Response, jsonify, request
 
 from reviveme import db
 from reviveme.models import Comment, Thread
 
+from marshmallow import Schema, fields, post_load, validate, validates
+
 from . import bp
+
+class CommentSchema(Schema):
+    content = fields.Str(required=True, validate=validate.Length(min=1))
+    parent_id = fields.Int()
+
+    author_id = None # set this before calling load()
+    thread_id = None # set this before calling load()
+
+    @validates("parent_id")
+    def validate_parent_id(self, parent_id):
+        if parent_id is not None and db.session.get(Comment, parent_id) is None:
+            raise ValueError(f"Comment with id {parent_id} does not exist")
+
+    @post_load
+    def make_comment(self, data, **kwargs) -> Comment:
+        return Comment(**data, author_id=self.author_id, thread_id=self.thread_id)
 
 class CommentNode:
     '''
@@ -71,22 +89,10 @@ def comment_create(thread_id):
     if db.session.get(Thread, thread_id) is None:
         return Response(f"Thread with id {thread_id} not found", status=404)
 
-    # TODO validate data in request body
+    schema = CommentSchema()
     # TODO: get author_id from token once auth is implemented
-    if "parent_id" in data:
-        db.get_or_404(Comment, data["parent_id"])
-        comment = Comment(
-            content=data["content"],
-            thread_id=thread_id,
-            author_id=1,
-            parent_id=data["parent_id"],
-        )
-    else:
-        comment = Comment(
-            content=data["content"], 
-            thread_id=thread_id, 
-            author_id=1
-        )
+    schema.author_id, schema.thread_id = 1, thread_id
+    comment = schema.load(data, thread_id=thread_id, author_id=1)
     db.session.add(comment)
     db.session.commit()
     return Response(status=201)
@@ -96,7 +102,11 @@ def comment_create(thread_id):
 def comment_update(comment_id):
     comment = db.get_or_404(Comment, comment_id)
     data: Any = request.json
-    # TODO validate incoming data
+
+    errors = CommentSchema().validate(data, partial=("content",))
+    if errors:
+        return jsonify(errors), 400
+
     comment.content = data["content"]
     db.session.commit()
     return Response(status=200)

--- a/reviveme/tests/test_comment_controller.py
+++ b/reviveme/tests/test_comment_controller.py
@@ -243,6 +243,19 @@ class TestCommentController:
         })
         assert response.status_code == 404
 
+    def test_create_comment_invalid_parent(self, client, thread):
+        response = client.post(f'/api/v1/threads/{thread.id}/comments', json={
+            "content": "Test Comment",
+            "parent_id": 1
+        })
+        assert response.status_code == 400
+
+    def test_create_comment_invalid_content(self, client, thread):
+        response = client.post(f'/api/v1/threads/{thread.id}/comments', json={
+            "content": ""
+        })
+        assert response.status_code == 400
+
     def test_update_comment(self, client, comment):
         response = client.put(f'/api/v1/comments/{comment.id}', json={
             "content": "Updated Comment"
@@ -258,6 +271,12 @@ class TestCommentController:
             "content": "Updated Comment"
         })
         assert response.status_code == 404
+
+    def test_update_comment_invalid_content(self, client, comment):
+        response = client.put(f'/api/v1/comments/{comment.id}', json={
+            "content": ""
+        })
+        assert response.status_code == 400
 
     def test_delete_comment(self, client, comment):
         response = client.delete(f'/api/v1/comments/{comment.id}')

--- a/reviveme/tests/test_thread_controller.py
+++ b/reviveme/tests/test_thread_controller.py
@@ -82,6 +82,65 @@ class TestThreadController():
             "content": "Test Content",
         })
         assert response.status_code == 201
+    
+    def test_create_thread_400(self, client, user):
+        invalid_inputs = [
+            {"title": "Test Thread"},
+            {"content": "Test Content"},
+            {"title": "Test Thread", "content": "Test Content", "invalid": "invalid"},
+            {"title": "", "content": "Test Content"},
+        ]
+
+        for inp in invalid_inputs:
+            response = client.post('/api/v1/threads', json=inp)
+            assert response.status_code == 400
+
+    def test_update_thread(self, client, thread):
+        response = client.put(f'/api/v1/threads/{thread.id}', json={
+            "title": "Updated Title",
+            "content": "Updated Content",
+        })
+        assert response.status_code == 200
+
+        thread = db.session.get(Thread, thread.id)
+        assert thread.title == "Updated Title"
+        assert thread.content == "Updated Content"
+    
+    def test_update_thread_title(self, client, thread):
+        response = client.put(f'/api/v1/threads/{thread.id}', json={
+            "title": "Updated Title",
+        })
+        assert response.status_code == 200
+
+        thread = db.session.get(Thread, thread.id)
+        assert thread.title == "Updated Title"
+        assert thread.content == "Test Content"
+    
+    def test_update_thread_content(self, client, thread):
+        response = client.put(f'/api/v1/threads/{thread.id}', json={
+            "content": "Updated Content",
+        })
+        assert response.status_code == 200
+
+        thread = db.session.get(Thread, thread.id)
+        assert thread.title == "Test Thread"
+        assert thread.content == "Updated Content"
+
+    def test_update_thread_404(self, client):
+        response = client.put('/api/v1/threads/1', json={
+            "title": "Updated Title",
+            "content": "Updated Content",
+        })
+        assert response.status_code == 404
+    
+    def test_update_thread_400(self, client, thread):
+        invalid_inputs = [
+            {"title": ""},
+        ]
+        for inp in invalid_inputs:
+            response = client.put(f'/api/v1/threads/{thread.id}', json=inp)
+            assert response.status_code == 400
+            assert thread.title != inp["title"]
 
     def test_delete_thread(self, client, thread):
         response = client.delete(f'/api/v1/threads/{thread.id}')


### PR DESCRIPTION
Implemented input validation and deserialization using marshmallow. To do this, I added new `Schema` classes. The instance variables that are set to `fields.*` represent fields in the input JSON object. The other variables (`author_id` and `thread_id`) are just things I added to pass info to the method that creates our ORM objects.

Marshmallow also allows us to serialize our models into json (to use in our responses). But I decided to leave that alone for now, because right now defining `.serialize` methods seems to work pretty okay for us.
