### PR TITLE
Handle deleted threads/comments properly in comment/thread list/edit endpoints

### DIFF
--- a/reviveme/api/v1/comment_controller.py
+++ b/reviveme/api/v1/comment_controller.py
@@ -101,6 +101,9 @@ def comment_create(thread_id):
 @bp.route("/comments/<int:comment_id>", methods=["PUT"])
 def comment_update(comment_id):
     comment = db.get_or_404(Comment, comment_id)
+    if comment.deleted:
+        return Response(status=400, response=f"Comment with id {comment_id} has been deleted")
+
     data: Any = request.json
 
     errors = CommentSchema().validate(data, partial=("content",))

--- a/reviveme/api/v1/thread_controller.py
+++ b/reviveme/api/v1/thread_controller.py
@@ -18,7 +18,7 @@ class ThreadSchema(Schema):
 
 @bp.route("/threads", methods=["GET"])
 def thread_list():
-    threads = db.session.execute(db.select(Thread)).scalars().all()
+    threads = db.session.execute(db.select(Thread).where(Thread.deleted == False)).scalars().all()
     return [thread.serialize() for thread in threads]
 
 

--- a/reviveme/api/v1/thread_controller.py
+++ b/reviveme/api/v1/thread_controller.py
@@ -41,6 +41,9 @@ def thread_create():
 @bp.route("/threads/<int:id>", methods=["PUT"])
 def thread_update(id):
     thread = db.get_or_404(Thread, id)
+    if thread.deleted:
+        return Response(status=400, response=f"Thread with id {id} has been deleted")
+
     data = request.get_json()
 
     errors = ThreadSchema().validate(data, partial=True)


### PR DESCRIPTION
We should still include deleted comments in the list endpoint so we can see their children, so that endpoint remains unchanged.