### PR TITLE
Refactor serialization

### DIFF
--- a/reviveme/api/v1/comment_controller.py
+++ b/reviveme/api/v1/comment_controller.py
@@ -9,7 +9,7 @@ from reviveme.models.thread import Thread
 from reviveme.models.comment import Comment
 
 from marshmallow import Schema, fields, post_load, post_dump, validate, validates, ValidationError
-from sqlalchemy import select, func
+from sqlalchemy import select
 
 from . import bp
 

--- a/reviveme/api/v1/thread_controller.py
+++ b/reviveme/api/v1/thread_controller.py
@@ -1,6 +1,6 @@
 from flask import Response, request, jsonify
 from marshmallow import Schema, fields, post_load, post_dump, validate
-from sqlalchemy import select, func
+from sqlalchemy import select
 
 from reviveme import db
 from reviveme.models import ThreadVote

--- a/reviveme/api/v1/thread_controller.py
+++ b/reviveme/api/v1/thread_controller.py
@@ -1,6 +1,8 @@
 from flask import Response, request, jsonify
-from marshmallow import Schema, fields, post_load, validate
+from marshmallow import Schema, fields, post_load, pre_dump, post_dump, validate
 from sqlalchemy import select, func
+
+import copy
 
 from reviveme import db
 from reviveme.models import Thread, ThreadVote
@@ -15,6 +17,38 @@ class ThreadSchema(Schema):
     @post_load
     def make_thread(self, data, **kwargs) -> Thread:
         return Thread(**data)
+
+class ThreadResponseSchema(Schema):
+    id = fields.Int()
+    author_username = fields.Function(lambda obj: obj.author.username if not obj.deleted else None)
+    title = fields.Function(lambda obj: obj.title if not obj.deleted else None)
+    content = fields.Function(lambda obj: obj.content if not obj.deleted else None)
+    deleted = fields.Bool(required=True)
+
+    upvoted = fields.Bool()
+    downvoted = fields.Bool()
+    score = fields.Int()
+
+    def get_author_username(self, obj: Thread):
+        return obj.author.username if not obj.deleted else None
+
+    def get_title(self, obj: Thread):
+        return obj.title if not obj.deleted else None
+    
+    def get_content(self, obj: Thread):
+        return obj.content if not obj.deleted else None
+
+    @post_dump(pass_original=True)
+    def append_vote_data(self, data, thread: Thread, **kwargs):
+        upvoted, downvoted = get_thread_upvoted(
+            thread.id, user_id=self.context['user_id']
+        )
+        return {
+            **data,
+            'upvoted': upvoted,
+            'downvoted': downvoted,
+            'score': get_thread_score(thread_id=thread.id)
+        }
 
 
 def get_thread_score(thread_id):
@@ -38,27 +72,15 @@ def get_thread_upvoted(thread_id, user_id):
 @bp.route("/threads", methods=["GET"])
 def thread_list():
     threads = db.session.execute(db.select(Thread).where(Thread.deleted == False)).scalars().all()
-    thread_dicts = [thread.serialize() for thread in threads]
 
-    # append vote and score data to results
-    for thread_dict in thread_dicts:
-        # TODO: get actual user id
-        upvoted, downvoted = get_thread_upvoted(thread_id=thread_dict['id'], user_id=1)
-        thread_dict['upvoted'] = upvoted
-        thread_dict['downvoted'] = downvoted
-        thread_dict['score'] = get_thread_score(thread_id=thread_dict['id'])
-    
-    return thread_dicts
+    schema = ThreadResponseSchema(context={'user_id': 1})
+    return [schema.dump(thread) for thread in threads]
 
 
 @bp.route("/threads/<int:id>", methods=["GET"])
 def thread_detail(id):
     thread = db.get_or_404(Thread, id)
-    resp_data = thread.serialize()
-    resp_data['score'] = get_thread_score(id)
-    # TODO: get actual user id
-    resp_data['upvoted'], resp_data['downvoted'] = get_thread_upvoted(thread_id=id, user_id=1)
-    return resp_data
+    return ThreadResponseSchema(context={'user_id': 1}).dump(thread)
 
 
 @bp.route("/threads", methods=["POST"])

--- a/reviveme/api/v1/vote_controller.py
+++ b/reviveme/api/v1/vote_controller.py
@@ -3,7 +3,9 @@ from flask import Response, request
 from marshmallow import Schema, fields
 
 from reviveme import db
-from reviveme.models import ThreadVote, CommentVote, Thread, Comment
+from reviveme.models import ThreadVote, CommentVote
+from reviveme.models.thread import Thread
+from reviveme.models.comment import Comment
 
 from sqlalchemy import select
 

--- a/reviveme/db/__init__.py
+++ b/reviveme/db/__init__.py
@@ -1,9 +1,3 @@
 from flask_sqlalchemy import SQLAlchemy
-from sqlalchemy.orm import DeclarativeBase
 
-
-class BaseModel(DeclarativeBase):
-    def serialize(self):
-        raise NotImplementedError
-
-db = SQLAlchemy(model_class=BaseModel)
+db = SQLAlchemy()

--- a/reviveme/models/__init__.py
+++ b/reviveme/models/__init__.py
@@ -1,5 +1,3 @@
-from .comment import Comment
-from .thread import Thread
 from .user import User
 from .thread_vote import ThreadVote
 from .comment_vote import CommentVote

--- a/reviveme/models/thread.py
+++ b/reviveme/models/thread.py
@@ -28,8 +28,7 @@ class Thread(db.Model):
     def serialize(self):
         return {
             "id": self.id,
-            "author_id": self.author_id if not self.deleted else None,
-            'author_username': self.author.username if not self.deleted else None,
+            "author_username": self.author.username if not self.deleted else None,
             "title": self.title if not self.deleted else None,
             "content": self.content if not self.deleted else None,
             "author_name": self.author.username if not self.deleted else None,

--- a/reviveme/models/thread.py
+++ b/reviveme/models/thread.py
@@ -24,13 +24,3 @@ class Thread(db.Model):
 
     def __repr__(self):
         return f"<Thread id={self.id!r}, title={self.title!r}, author_id={self.author_id!r}>"
-
-    def serialize(self):
-        return {
-            "id": self.id,
-            "author_username": self.author.username if not self.deleted else None,
-            "title": self.title if not self.deleted else None,
-            "content": self.content if not self.deleted else None,
-            "author_name": self.author.username if not self.deleted else None,
-            "deleted": self.deleted,
-        }

--- a/reviveme/scripts/add_fake_data.py
+++ b/reviveme/scripts/add_fake_data.py
@@ -7,7 +7,9 @@ from flask_migrate import upgrade
 from config import FLASK_APP
 from reviveme import create_app
 from reviveme.db import db
-from reviveme.models import Comment, Thread, User
+from reviveme.models import User
+from reviveme.models.thread import Thread
+from reviveme.models.comment import Comment
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"

--- a/reviveme/tests/test_comment_controller.py
+++ b/reviveme/tests/test_comment_controller.py
@@ -1,4 +1,5 @@
 import pytest
+from reviveme.api.v1.comment_controller import CommentResponseSchema
 
 from reviveme.db import db
 from reviveme.models.thread import Thread
@@ -147,58 +148,63 @@ class TestCommentController:
         db.session.commit()
         return comments
 
-    def test_list_comments(self, client, comments):
+    def test_list_comments(self, user, client, comments):
         response = client.get(f'/api/v1/threads/{comments[0].thread.id}/comments')
         assert response.status_code == 200
-        assert response.json == [ {**comment.serialize(), "children": [], "score": 0} for comment in comments ]
 
-    def test_list_comments_multiple_threads(self, client, comments_on_multiple_threads):
+        schema = CommentResponseSchema(context={'user_id': user.id})
+        for comment, response_comment in zip(comments, response.json):
+            assert response_comment == {**schema.dump(comment), 'children': []}
+            assert response_comment['content'] == comment.content
+
+    def test_list_comments_multiple_threads(self, user, client, comments_on_multiple_threads):
         response = client.get(f'/api/v1/threads/{comments_on_multiple_threads[0].thread.id}/comments')
         assert response.status_code == 200
-        assert response.json == [ {**comments_on_multiple_threads[0].serialize(), "children": [], "score": 0} ]
+
+        schema = CommentResponseSchema(context={'user_id': user.id})
+        assert response.json == [ 
+            {**schema.dump(comments_on_multiple_threads[0]), "children": []}
+        ]
 
         response = client.get(f'/api/v1/threads/{comments_on_multiple_threads[1].thread.id}/comments')
         assert response.status_code == 200
-        assert response.json == [ {**comment.serialize(), "children": [], "score": 0} for comment in comments_on_multiple_threads[1:] ]
+        assert response.json == [ 
+            {**schema.dump(comment), "children": []} for comment in comments_on_multiple_threads[1:] 
+        ]
     
-    def test_list_comments_nested(self, client, nested_comments):
+    def test_list_comments_nested(self, user, client, nested_comments):
         top_level_comments, child_comments, grandchild_comments = nested_comments
         response = client.get(f'/api/v1/threads/{top_level_comments[0].thread_id}/comments')
         assert response.status_code == 200
 
+        schema = CommentResponseSchema(context={'user_id': user.id})
         expected_response = [
             {
-                **top_level_comments[0].serialize(),
+                **schema.dump(top_level_comments[0]),
                 "children": [
                     {
-                        **child_comments[0].serialize(),
+                        **schema.dump(child_comments[0]),
                         "children": [
                             {
-                                **grandchild_comments[0].serialize(),
+                                **schema.dump(grandchild_comments[0]),
                                 "children": [],
-                                "score": 0
                             }
                         ],
-                        "score": 0
                     },
                     {
-                        **child_comments[1].serialize(),
+                        **schema.dump(child_comments[1]),
                         "children": [],
-                        "score": 0
                     }
                 ],
-                "score": 0
             },
             {
-                **top_level_comments[1].serialize(),
+                **schema.dump(top_level_comments[1]),
                 "children": [
                     { 
-                        **child_comments[2].serialize(), 
+                        **schema.dump(child_comments[2]), 
                         "children": [], 
-                        "score": 0
                     }
                 ],
-                "score": 0
             }
         ]
         
@@ -208,10 +214,12 @@ class TestCommentController:
         response = client.get('/api/v1/threads/1/comments')
         assert response.status_code == 404
     
-    def test_get_comment(self, client, comment):
+    def test_get_comment(self, user, client, comment):
         response = client.get(f'/api/v1/comments/{comment.id}')
         assert response.status_code == 200
-        assert response.json == {**comment.serialize(), "score": 0}
+        schema = CommentResponseSchema(context={'user_id': user.id})
+        assert response.json == schema.dump(comment)
+        assert response.json['content'] == comment.content
 
     def test_get_comment_404(self, client):
         response = client.get('/api/v1/comments/1')
@@ -296,7 +304,7 @@ class TestCommentController:
         assert resp.status_code == 200
         assert resp.json["deleted"] == True
         assert resp.json["content"] == None
-        assert resp.json["author_id"] == None
+        assert resp.json["author_username"] == None
     
     def test_delete_comment_404(self, client):
         response = client.delete('/api/v1/comments/1')

--- a/reviveme/tests/test_comment_controller.py
+++ b/reviveme/tests/test_comment_controller.py
@@ -1,7 +1,8 @@
 import pytest
 
 from reviveme.db import db
-from reviveme.models import Thread, Comment
+from reviveme.models.thread import Thread
+from reviveme.models.comment import Comment
 
 class TestCommentController:
     @pytest.fixture()

--- a/reviveme/tests/test_thread_controller.py
+++ b/reviveme/tests/test_thread_controller.py
@@ -1,7 +1,7 @@
 import pytest
 
 from reviveme.db import db
-from reviveme.models import Thread
+from reviveme.models.thread import Thread
 
 class TestThreadController():
     @pytest.fixture()

--- a/reviveme/tests/test_thread_controller.py
+++ b/reviveme/tests/test_thread_controller.py
@@ -1,4 +1,5 @@
 import pytest
+from reviveme.api.v1.thread_controller import ThreadResponseSchema
 
 from reviveme.db import db
 from reviveme.models.thread import Thread
@@ -35,15 +36,24 @@ class TestThreadController():
         db.session.commit()
         return threads
 
-    def test_get_threads(self, client, threads):
+    def test_get_threads(self, user, client, threads):
         response = client.get('/api/v1/threads')
         assert response.status_code == 200
-        assert response.json == [{**thread.serialize(), "score": 0} for thread in threads]
+        
+        schema = ThreadResponseSchema(context={'user_id': user.id})
+        for thread, response_thread in zip(threads, response.json):
+            assert response_thread == schema.dump(thread)
+            assert response_thread['title'] == thread.title
+            assert response_thread['content'] == thread.content
 
-    def test_get_thread(self, client, thread):
+    def test_get_thread(self, user, client, thread):
         response = client.get(f'/api/v1/threads/{thread.id}')
         assert response.status_code == 200
-        assert response.json == {**thread.serialize(), "score": 0}
+
+        schema = ThreadResponseSchema(context={'user_id': user.id})
+        assert response.json == schema.dump(thread)
+        assert response.json['title'] == thread.title
+        assert response.json['content'] == thread.content
         
     def test_get_thread_404(self, client):
         response = client.get('/api/v1/threads/1')
@@ -125,8 +135,7 @@ class TestThreadController():
         response = client.get(f'/api/v1/threads/{thread.id}')
         assert response.status_code == 200
         assert response.json["deleted"] == True
-        assert response.json["author_id"] == None
-        assert response.json["author_name"] == None
+        assert response.json["author_username"] == None
         assert response.json["title"] == None
         assert response.json["content"] == None
 

--- a/reviveme/tests/test_vote_controller.py
+++ b/reviveme/tests/test_vote_controller.py
@@ -1,7 +1,8 @@
 import pytest
 
 from reviveme.db import db
-from reviveme.models import Thread, Comment
+from reviveme.models.thread import Thread
+from reviveme.models.comment import Comment
 
 class TestVoteController:
     """


### PR DESCRIPTION
This is a tentative change, I tried to organize the code a little more without sacrificing readability too much. Let me know what you think.

This change is meant to:

- Remove some code duplication (for example, we were adding score to our thread response data in both the `list` and `get` endpoints)
- Separate some of the code responsible for interfacing with the database away from the serialization code
  - Single-responsibility principle - ideally we don't want our serializer classes to be responsible for calculating data as well as transforming it to JSON
  - This also lets us get the score of a thread by simply writing `thread.score`. This functionality is also available everywhere we use the thread model. The same thing is true for comments.

Points to consider for the future:
- whether we want to use [flask-marshmallow](https://flask-marshmallow.readthedocs.io/en/latest/) and/or [marshmallow-sqlalchemy](https://marshmallow-sqlalchemy.readthedocs.io/en/latest/index.html). We might be able to use them to automatically generate schemas from our sql alchemy models
  - Advantages: removes some boilerplate (we currently have to every field we want to pass and its type in its response schema. This might remove the need to do that for future endpoints)
  - Disadvantages: more abstraction can make our code a little too cryptic and compromise readability.
- If we need it in the future, we can change `score` from a `property` to a sqlalchemy `hybrid_property` instead. This allows us to specify a query expression to get the score. This in turn lets us write sqlalchemy queries as if score was a column in our table.
- Maybe we could figure out a way to move the logic that determines the `upvoted` and `downvoted` response fields away from the serializer.