### PR TITLE
Add created_at date to threads and comments

### DIFF
--- a/reviveme/__init__.py
+++ b/reviveme/__init__.py
@@ -11,6 +11,8 @@ def create_app(testing=False):
     if testing:
         app.config["TESTING"] = True
         app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    else:
+        app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {'connect_args': {'options': '-c timezone=utc'}}
 
     db.init_app(app)
     migrate = Migrate(app, db)

--- a/reviveme/api/v1/comment_controller.py
+++ b/reviveme/api/v1/comment_controller.py
@@ -35,6 +35,7 @@ class CommentResponseSchema(Schema):
     thread_id = fields.Int()
     content = fields.Function(lambda obj: obj.content if not obj.deleted else None)
     deleted = fields.Bool()
+    created_at = fields.DateTime()
     score = fields.Int()
 
     @post_dump(pass_original=True)

--- a/reviveme/api/v1/thread_controller.py
+++ b/reviveme/api/v1/thread_controller.py
@@ -23,6 +23,7 @@ class ThreadResponseSchema(Schema):
     title = fields.Function(lambda obj: obj.title if not obj.deleted else None)
     content = fields.Function(lambda obj: obj.content if not obj.deleted else None)
     deleted = fields.Bool(required=True)
+    created_at = fields.DateTime()
     score = fields.Int()
 
     @post_dump(pass_original=True)

--- a/reviveme/models/comment.py
+++ b/reviveme/models/comment.py
@@ -1,4 +1,5 @@
-from sqlalchemy import ForeignKey, Text, Integer, Boolean, select, func
+from datetime import datetime
+from sqlalchemy import DateTime, ForeignKey, Text, Integer, Boolean, select, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import Union
 
@@ -16,6 +17,7 @@ class Comment(db.Model):
     parent_id: Mapped[Union[int, None]] = mapped_column(ForeignKey("comments.id"))
     depth: Mapped[int] = mapped_column(Integer, default=1)
     deleted: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     thread: Mapped["Thread"] = relationship("Thread", back_populates="comments")
     author: Mapped["User"] = relationship("User")

--- a/reviveme/models/comment.py
+++ b/reviveme/models/comment.py
@@ -17,7 +17,7 @@ class Comment(db.Model):
     parent_id: Mapped[Union[int, None]] = mapped_column(ForeignKey("comments.id"))
     depth: Mapped[int] = mapped_column(Integer, default=1)
     deleted: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     thread: Mapped["Thread"] = relationship("Thread", back_populates="comments")
     author: Mapped["User"] = relationship("User")

--- a/reviveme/models/thread.py
+++ b/reviveme/models/thread.py
@@ -13,7 +13,7 @@ class Thread(db.Model):
     title: Mapped[str] = mapped_column(String(120))
     content: Mapped[str] = mapped_column(String(10000))
     deleted: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     comments: Mapped[List["Comment"]] = relationship("Comment", back_populates="thread")
     author: Mapped["User"] = relationship("User", back_populates="threads")

--- a/reviveme/models/thread.py
+++ b/reviveme/models/thread.py
@@ -1,7 +1,8 @@
 from typing import List
 
-from sqlalchemy import ForeignKey, String, Boolean, select, func
+from sqlalchemy import DateTime, ForeignKey, String, Boolean, select, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from datetime import datetime
 
 from reviveme.db import db
 from .thread_vote import ThreadVote
@@ -12,6 +13,7 @@ class Thread(db.Model):
     title: Mapped[str] = mapped_column(String(120))
     content: Mapped[str] = mapped_column(String(10000))
     deleted: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     comments: Mapped[List["Comment"]] = relationship("Comment", back_populates="thread")
     author: Mapped["User"] = relationship("User", back_populates="threads")


### PR DESCRIPTION
Sister PR: https://github.com/Seanlebon/reviveme-fe/pull/8

This change adds a `created_at` column to our thread and comment tables. Additionally, we pass in a little extra configuration that tells the DB server to calculate the created_at date/time itself.

Still to do:

- [x] Account for time zone differences - we might want to save the time stamp in Greenwich time (UTC+0) and adjust it to match the user's time zone on the frontend