### PR TITLE
Add sorting for threads and comments

### DIFF
--- a/reviveme/__init__.py
+++ b/reviveme/__init__.py
@@ -10,9 +10,11 @@ def create_app(testing=False):
 
     if testing:
         app.config["TESTING"] = True
-        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"        
     else:
         app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {'connect_args': {'options': '-c timezone=utc'}}
+        if app.config["ENVIRONMENT"] == 'development':
+            app.config["SQLALCHEMY_ENGINE_OPTIONS"]['echo'] = True
 
     db.init_app(app)
     migrate = Migrate(app, db)

--- a/reviveme/api/v1/thread_controller.py
+++ b/reviveme/api/v1/thread_controller.py
@@ -5,6 +5,9 @@ from sqlalchemy import select, desc, case
 from reviveme import db
 from reviveme.models import ThreadVote
 from reviveme.models.thread import Thread
+
+from reviveme.constants.params import SortParams
+
 from . import bp
 
 
@@ -48,12 +51,12 @@ def get_thread_upvoted(thread_id, user_id):
 
 @bp.route("/threads", methods=["GET"])
 def thread_list():
-    sort_by = request.args.get("sortby", "newest", type=str)
+    sort_by = request.args.get("sortby", SortParams.NEWEST, type=str)
 
     select_statement = db.select(Thread).where(Thread.deleted == False)
-    if sort_by == "newest":
+    if sort_by == SortParams.NEWEST:
         select_statement = select_statement.order_by(desc(Thread.created_at))
-    elif sort_by == "top":
+    elif sort_by == SortParams.TOP:
         # left outer join on ThreadVote to get thread score
         select_statement = select_statement.outerjoin(ThreadVote, full=False).group_by(Thread.id).order_by(
             desc(

--- a/reviveme/api/v1/thread_controller.py
+++ b/reviveme/api/v1/thread_controller.py
@@ -1,6 +1,6 @@
 from flask import Response, request, jsonify
 from marshmallow import Schema, fields, post_load, post_dump, validate
-from sqlalchemy import select
+from sqlalchemy import select, desc, case
 
 from reviveme import db
 from reviveme.models import ThreadVote
@@ -48,7 +48,22 @@ def get_thread_upvoted(thread_id, user_id):
 
 @bp.route("/threads", methods=["GET"])
 def thread_list():
-    threads = db.session.execute(db.select(Thread).where(Thread.deleted == False)).scalars().all()
+    sort_by = request.args.get("sortby", "newest", type=str)
+
+    select_statement = db.select(Thread).where(Thread.deleted == False)
+    if sort_by == "newest":
+        select_statement = select_statement.order_by(desc(Thread.created_at))
+    elif sort_by == "top":
+        # left outer join on ThreadVote to get thread score
+        select_statement = select_statement.outerjoin(ThreadVote, full=False).group_by(Thread.id).order_by(
+            desc(
+                db.func.sum(
+                    case((ThreadVote.upvote == True, 1), (ThreadVote.upvote == False, -1), else_=0)
+                )
+            )
+        )
+
+    threads = db.session.execute(select_statement).scalars().all()
 
     schema = ThreadResponseSchema(context={'user_id': 1})
     return [schema.dump(thread) for thread in threads]

--- a/reviveme/constants/params.py
+++ b/reviveme/constants/params.py
@@ -1,0 +1,3 @@
+class SortParams:
+    NEWEST = 'newest'
+    TOP = 'top'


### PR DESCRIPTION
The sort type is specified in the URL parameters. The two types I've made so far are "newest" and "top". This change also adds logging of sql queries generated by sqlalchemy. This is useful for debugging complicated queries like the sort by top one I added here.

Sister PR: https://github.com/Seanlebon/reviveme-fe/pull/9